### PR TITLE
Feature/add random forest shap 20231111

### DIFF
--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import streamlit as st
 
-from services import prophet
+from services import prophet, random_forest_regressor
 from services.utils import read_dataset
 
 
@@ -21,7 +21,9 @@ def display():
         df_with_prophet = prophet.extract_prophet_data(
             pred, mmm_df, target_prophet_cols=["trend", "yearly"]
         )
-        # st.table(df_with_prophet)
+        rmse, r2_score = plot_random_forest_predict(df_with_prophet)
+        # print(rmse)
+        # print(r2_score)
 
 
 def plot_cost_and_revenue(
@@ -32,3 +34,16 @@ def plot_cost_and_revenue(
 ):
     st.line_chart(data=df, x=date_column, y=revenue_columns)
     st.line_chart(data=df, x=date_column, y=cost_columns)
+
+
+def plot_random_forest_predict(
+    df_with_prophet: pd.DataFrame, target_column="sales"
+) -> (float, float):
+    rf_model, pred = random_forest_regressor.regressor(
+        df_with_prophet, target_column, list(df_with_prophet.columns)[2:]
+    )
+
+    rmse, r2_score = random_forest_regressor.calc_rmse_r2(
+        df_with_prophet[target_column], pred
+    )
+    return rmse, r2_score

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit==1.28.1
 pandas==2.1.2
 prophet==1.1.5
+scikit-learn==1.3.2

--- a/services/random_forest_regressor.py
+++ b/services/random_forest_regressor.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.metrics import mean_squared_error, r2_score
+from sklearn.model_selection import TimeSeriesSplit
+
+
+def make_random_forest_model(
+    n_estimators: int,
+    max_depth: int,
+    min_samples_split: int,
+    min_samples_leaf: int,
+    ccp_alpha: float,
+    bootstrap: bool = True,
+    random_state: int = 123,
+) -> RandomForestRegressor:
+    """
+    ランダムフォレストのモデルを生成する
+    args:
+      n_estimators :The number of trees in the forest
+      max_depth: The maximum depth of the tree
+      min_samples_split: The minimum number of samples required to split an internal node
+      min_samples_leaf: The minimum number of samples required to be at a leaf node
+      bootstrap: Whether bootstrap samples are used when building trees
+      random_state: Controls the randomness
+      ccp_alpha: Complexity parameter used for Minimal Cost-Complexity Pruning
+    """
+    params = {
+        "n_estimators": n_estimators,
+        "max_depth": max_depth,
+        "min_samples_split": min_samples_split,
+        "min_samples_leaf": min_samples_leaf,
+        "bootstrap": bootstrap,
+        "random_state": random_state,
+        "ccp_alpha": ccp_alpha,
+    }
+    rf = RandomForestRegressor(**params)
+    return rf
+
+
+def fit_predict_rf_model(
+    rf_model: RandomForestRegressor,
+    x_train: pd.DataFrame,
+    y_train: pd.DataFrame,
+    x_test: pd.DataFrame,
+) -> np.ndarray:
+    rf_model.fit(x_train, y_train)
+    pred = rf_model.predict(x_test)
+    # Shapの計算に、RandomForestRegressorを用いるため、モデルをreturnする
+    return (rf_model, pred)
+
+
+def calc_rmse_r2(y_true, y_pred) -> (float, float):
+    rmse = mean_squared_error(y_true, y_pred, squared=False)
+    r2 = r2_score(y_true, y_pred)
+    return rmse, r2
+
+
+def regressor(
+    df: pd.DataFrame, target_column: str, feature_columns: list[str]
+) -> (RandomForestRegressor, np.ndarray):
+    tscv = TimeSeriesSplit(n_splits=3, test_size=10)
+    for train_index, test_index in tscv.split(df):
+        x_train = df.iloc[train_index][feature_columns]
+        y_train = df[target_column].values[train_index]
+
+    rf = make_random_forest_model(20, 9, 4, 8, 0.15)
+    return fit_predict_rf_model(rf, x_train, y_train, df[feature_columns])


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
 - MMMに、ランダムフォレスト推論機能を追加したい
   - 推論結果を、r2score, rmseで精度検証する

# チケット・参考リンク
 - なし

# 変更内容
 - 必要ライブラリの追加
 - ランダムフォレスト推論機能の実装
 - 精度検証メソッドの追加

# 動作確認（確認方法とプロセスを明確に記載する）
 - streamlit上で動作確認を実施。r2score及びrmseがprintされることを確認

<img width="888" alt="" src="https://github.com/quackshift-jp/marketing-mix-modeling/assets/110513314/55281e8e-2dd4-4987-b6e1-935d837bdb28">



# チェックポイント
- [x] 動作確認は実施したか
- [x] プルリクにラベル付けは実施しているか
