### PR TITLE
Feature/add response curve 20231112

### DIFF
--- a/future_predict.py
+++ b/future_predict.py
@@ -1,0 +1,8 @@
+import pandas as pd
+from prophet import Prophet
+
+
+def get_prophet_future_data(prophet_model: Prophet) -> pd.DataFrame:
+    future = prophet_model.make_future_dataframe(periods=30)
+    prophet_future_data = prophet_model.predict(future)
+    return prophet_future_data

--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -2,7 +2,12 @@ import numpy as np
 import pandas as pd
 import streamlit as st
 
-from services import prophet, random_forest_regressor, shap_feature_importance
+from services import (
+    draw_response_curve,
+    prophet,
+    random_forest_regressor,
+    shap_feature_importance,
+)
 from services.utils import read_dataset
 
 SALES_COLUMNS = ["tvcm", "newspaper", "web"]
@@ -34,7 +39,15 @@ def display():
         st.pyplot(shap_feature_importance.plot_roi(feature_importance))
         st.pyplot(shap_feature_importance.plot_spend_effect_share(feature_importance))
 
+        for feature in SALES_COLUMNS:
+            st.pyplot(
+                draw_response_curve.response_curve(shap_df, df_with_prophet, feature)
+            )
 
+        calc_mean_spend(df_with_prophet, SALES_COLUMNS)
+
+
+# TODO:下の関数は、servicesディレクトリに移動させたい
 def plot_cost_and_revenue(
     df: pd.DataFrame,
     date_column: str,
@@ -43,6 +56,13 @@ def plot_cost_and_revenue(
 ):
     st.line_chart(data=df, x=date_column, y=revenue_columns)
     st.line_chart(data=df, x=date_column, y=cost_columns)
+
+
+def calc_mean_spend(cost_df: pd.DataFrame, features: list[str]):
+    st.write("平均コスト")
+    for feature in features:
+        mean_spend = cost_df[feature].mean().astype("int")
+        st.write(f"{feature}:{mean_spend}/週")
 
 
 def random_forest_predict(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pandas==2.1.2
 prophet==1.1.5
 scikit-learn==1.3.2
 shap==0.43.0
+seaborn==0.13.0
+statsmodels==0.14.0

--- a/services/draw_response_curve.py
+++ b/services/draw_response_curve.py
@@ -1,0 +1,30 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+
+
+def response_curve(
+    df_shap_values: pd.DataFrame,
+    cost_df: pd.DataFrame,
+    feature: str,
+) -> plt.figure:
+    """
+    各チャネルのレスポンスカーブをregplotで回帰モデルに可視化する
+    """
+    fig, ax = plt.subplots(figsize=(10, 6))
+    plt.ticklabel_format(style="plain", axis="y")
+    plt.ticklabel_format(style="plain", axis="x")
+    sns.regplot(
+        x=cost_df[feature],
+        y=df_shap_values[feature],
+        label=feature,
+        scatter_kws={"alpha": 0.5},
+        line_kws={"color": "C2", "linewidth": 3},
+        lowess=True,
+        ax=ax,
+    ).set(title=f"{feature}: Spend vs Shapley")
+    ax.axhline(0, linestyle="--", color="black", alpha=0.5)
+    ax.set_xlabel(f"{feature} spend")
+    ax.set_ylabel(f"SHAP Value for {feature}")
+
+    return fig


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
 - レスポンスカーブを可視化して、営業チャネルの最適コスト配分を予測したい

# チケット・参考リンク
 - なし

# 変更内容
 - レスポンスカーブを可視化するメソッド追加
 - ライブラリの追加

# 動作確認（確認方法とプロセスを明確に記載する）
 - ローカルにて動作確認済み

# チェックポイント
- [x] 動作確認は実施したか
- [x] プルリクにラベル付けは実施しているか
